### PR TITLE
travis: only test deployed ruby;  remove non-existent cap target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ notifications:
   email: false
 
 rvm:
-  - 2.4.0
   - 2.5.3

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,3 +1,0 @@
-server 'dor-services-dev.stanford.edu', user: 'dor_services', roles: %w(web app)
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
- ruby updated by puppet on VMs; app deployed afterwards.
- there is no dor-services-dev